### PR TITLE
Removes deprecated defaultShell and defaultPackage from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
           RUSTFLAGS = "-Z macro-backtrace";
         };
 
-        defaultPackage = axum-rest-example;
+        defaultPackages.default = axum-rest-example;
         packages = {
           inherit (pkgs.master) rust-analyzer sqlx-cli;
           inherit (pkgs) sccache;

--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
             axum-rest-example-fmt;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           name = "axum-rest-example-nightly";
           nativeBuildInputs = [ rustTools.default ] ++ sharedInputs;
 
@@ -164,7 +164,7 @@
 
           gcroot = pkgs.linkFarmFromDrvs "axum-rest-example"
             (with self.outputs; [
-              devShell."${system}".inputDerivation
+              devShells."${system}".default.inputDerivation
               devShells."${system}".nightly.inputDerivation
             ]);
         };


### PR DESCRIPTION
`nix flake  check` previously gave this warning

```
warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
warning: flake output attribute 'defaultPackage' is deprecated; use 'packages.<system>.default' instead
```

I believe this is the relevant change to nix flake https://github.com/NixOS/nix/issues/5532